### PR TITLE
Update README.md (Double quotes missing)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Ensure the categories `types` are set correctly in the config file.
 
 Run the seed (this will create root nodes for each of your category `types`)
 
-	php artisan db:seed --class=Fbf\LaravelCategories\CategoriesTableBaseSeeder
+	php artisan db:seed --class="Fbf\LaravelCategories\CategoriesTableBaseSeeder"
 
 Build your menus in the database, or if you are using FrozenNode's Laravel Administrator, see the info below
 


### PR DESCRIPTION
Change 
    `php artisan db:seed --class=Fbf\LaravelCategories\CategoriesTableBaseSeeder` 
by 
`php artisan db:seed --class="Fbf\LaravelCategories\CategoriesTableBaseSeeder"` 
otherwise beginners can get trouble
